### PR TITLE
Login credentials and Admin delete capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,12 @@ php artisan migrate --seed
 
 composer run dev
 ```
-
+Open your browser and access the application through http://127.0.0.1:8000
+Use the following credentials
+```
+Emial : test@example.com
+Password : password
+```
 ## 🤝 Contributing
 
 All contributions are welcome. Please fork the repo, create a feature branch and submit a pull request.

--- a/app/Filament/Resources/AdminResource.php
+++ b/app/Filament/Resources/AdminResource.php
@@ -80,7 +80,7 @@ class AdminResource extends Resource
                 Tables\Actions\ActionGroup::make([
                     Tables\Actions\EditAction::make(),
                     Tables\Actions\ViewAction::make(),
-                    Tables\Actions\DeleteAction::make(),
+                    Tables\Actions\DeleteAction::make()->hidden(fn ($record)=> auth()->user()->email === $record->email),
                 ])
             ])
             ->bulkActions([


### PR DESCRIPTION

The update removes the delete action on the currently logged in admin to prevent oneself from deleting the account.
The other update is on the Readme.md file showing the login credentials.
